### PR TITLE
Fix http2 error while requesting https (#21)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -188,6 +188,7 @@ func main() {
 		// Load TLS certificate
 		tlsConfig = &tls.Config{
 			GetCertificate: kpr.GetCertificateFunc(),
+			NextProtos:     []string{"http/1.1"},
 		}
 	}
 


### PR DESCRIPTION
For some reasons default `tls.Config` by default offers ALPN `h2`, but server responds with `http/1.1`. Fixed by setting `NextProtos`.

```→  curl -k https://localhost -H 'Host: sonar.local' -v
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-ECDSA-AES128-GCM-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=sonar.local
*  start date: May 28 14:33:29 2020 GMT
*  expire date: May 28 14:33:29 2025 GMT
*  issuer: CN=Pebble Intermediate CA 7084c5
*  SSL certificate verify result: unable to get local issuer certificate (20), continuing anyway.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7fa1f000de00)
> GET / HTTP/2
> Host: sonar.local
> User-Agent: curl/7.64.1
> Accept: */*
>
* http2 error: Remote peer returned unexpected data while we expected SETTINGS frame.  Perhaps, peer does not support HTTP/2 properly.
* Connection #0 to host localhost left intact
curl: (16) Error in the HTTP2 framing layer
* Closing connection 0
```