### PR TITLE
Set users.id as owner column for users_id_seq

### DIFF
--- a/internal/database/migrations/000007_users_id_seq_owner.up.sql
+++ b/internal/database/migrations/000007_users_id_seq_owner.up.sql
@@ -1,0 +1,1 @@
+ALTER SEQUENCE users_id_seq OWNED BY users.id;


### PR DESCRIPTION
This fixes drop migrations command. Without "owned by" `users_id_seq` in not deleted on `users` table deletion.