### PR TITLE
Create separate db column for admin flag

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -64,11 +64,14 @@ func main() {
 	}
 
 	// Create admin user
-	admin := &models.User{Name: "admin", Params: models.UserParams{
-		Admin:      true,
-		TelegramID: cfg.Modules.Telegram.Admin,
-		APIToken:   cfg.Modules.API.Admin,
-	}}
+	admin := &models.User{
+		Name:    "admin",
+		IsAdmin: true,
+		Params: models.UserParams{
+			TelegramID: cfg.Modules.Telegram.Admin,
+			APIToken:   cfg.Modules.API.Admin,
+		},
+	}
 
 	if u, err := db.UsersGetByName("admin"); err == sql.ErrNoRows {
 		// There is no admin yet - create one

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -23,11 +23,9 @@ var (
 		},
 	}
 	admin = &models.User{
-		ID:   1,
-		Name: "admin",
-		Params: models.UserParams{
-			Admin: true,
-		},
+		ID:      1,
+		Name:    "admin",
+		IsAdmin: true,
 	}
 	payload = &models.Payload{
 		ID:     1,

--- a/internal/cmd/users.go
+++ b/internal/cmd/users.go
@@ -18,7 +18,7 @@ func UsersCmd(acts actions.Actions, handler ResultHandler) *cobra.Command {
 				return errors.Internal(err)
 			}
 
-			if !u.Params.Admin {
+			if !u.IsAdmin {
 				return errors.Forbidden()
 			}
 

--- a/internal/database/migrations/000008_separate_is_admin_field.down.sql
+++ b/internal/database/migrations/000008_separate_is_admin_field.down.sql
@@ -1,0 +1,6 @@
+WITH admins AS (
+    SELECT * FROM users WHERE is_admin = true
+)
+UPDATE users SET params = jsonb_set(users.params, '{admin}', 'true') FROM admins WHERE users.id = admins.id;
+
+ALTER TABLE users DROP COLUMN is_admin;

--- a/internal/database/migrations/000008_separate_is_admin_field.up.sql
+++ b/internal/database/migrations/000008_separate_is_admin_field.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE users ADD COLUMN is_admin BOOL NOT NULL DEFAULT false;
+
+WITH admins AS (
+    SELECT * FROM users WHERE (params->'admin')::BOOL = true
+)
+UPDATE users SET is_admin = true FROM admins WHERE users.id = admins.id;
+
+UPDATE users SET params = params #- '{admin}';

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -21,7 +21,8 @@ func (db *DB) UsersCreate(o *models.User) error {
 	}
 
 	nstmt, err := db.PrepareNamed(
-		"INSERT INTO users (name, params, created_at) VALUES(:name, :params, :created_at) RETURNING id")
+		"INSERT INTO users (name, params, is_admin, created_at) " +
+			"VALUES(:name, :params, :is_admin, :created_at) RETURNING id")
 
 	if err != nil {
 		return err

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -11,12 +11,12 @@ type User struct {
 	ID        int64      `db:"id"`
 	Name      string     `db:"name"`
 	Params    UserParams `db:"params"`
+	IsAdmin   bool       `db:"is_admin"`
 	CreatedAt time.Time  `db:"created_at"`
 }
 
 // It is required to add omitempty because of UsersGetByParams func
 type UserParams struct {
-	Admin      bool   `json:"admin,omitempty"       mapstructure:"admin"`
 	TelegramID int64  `json:"telegram.id,omitempty" mapstructure:"telegram.id"`
 	APIToken   string `json:"api.token,omitempty"   mapstructure:"api.token"`
 }


### PR DESCRIPTION
This is required to be able later to move params field into separate table (without `admin` field)