### PR TITLE
Move users.params into separate table user_params

### DIFF
--- a/internal/database/fixtures/user_params.yml
+++ b/internal/database/fixtures/user_params.yml
@@ -1,0 +1,29 @@
+- id: 1
+  user_id: 1
+  key: telegram.id
+  value: 31337
+
+- id: 2
+  user_id: 1
+  key: api.token
+  value: 50c862e41d059eeca13adc7b276b46b7
+
+- id: 3
+  user_id: 2
+  key: telegram.id
+  value: 31338
+
+- id: 4
+  user_id: 2
+  key: api.token
+  value: 7001f2d819d3d5fb0b1fd75dd38eb34e
+
+- id: 5
+  user_id: 3
+  key: telegram.id
+  value: 1337
+
+- id: 6
+  user_id: 3
+  key: api.token
+  value: a33bfdbfb3c62feb7ea59314dbd17426

--- a/internal/database/fixtures/users.yml
+++ b/internal/database/fixtures/users.yml
@@ -1,20 +1,12 @@
 - id: 1
   name: user1
-  params:
-    telegram.id: 31337
-    api.token: 50c862e41d059eeca13adc7b276b46b7
   created_at: RAW=NOW() AT TIME ZONE 'UTC'
 
 - id: 2
   name: user2
-  params:
-    telegram.id: 31338
-    api.token: 7001f2d819d3d5fb0b1fd75dd38eb34e
   created_at: RAW=NOW() AT TIME ZONE 'UTC'
 
 - id: 3
   name: admin
-  params:
-    telegram.id: 1337
-    api.token: a33bfdbfb3c62feb7ea59314dbd17426
+  is_admin: true
   created_at: RAW=NOW() AT TIME ZONE 'UTC'

--- a/internal/database/migrations/000009_user_params_table.down.sql
+++ b/internal/database/migrations/000009_user_params_table.down.sql
@@ -1,0 +1,17 @@
+ALTER TABLE users ADD COLUMN params JSONB NOT NULL DEFAULT '{}';
+
+UPDATE users
+SET params = jsonb_set(users.params, '{telegram.id}', to_jsonb(p.value::INT))
+FROM (
+    SELECT user_id, key, value FROM user_params
+) AS p
+WHERE user_id = users.id AND p.key = 'telegram.id';
+
+UPDATE users
+SET params = jsonb_set(users.params, '{api.token}', to_jsonb(p.value::TEXT))
+FROM (
+    SELECT user_id, key, value FROM user_params
+) AS p
+WHERE user_id = users.id AND p.key = 'api.token';
+
+DROP TABLE user_params;

--- a/internal/database/migrations/000009_user_params_table.up.sql
+++ b/internal/database/migrations/000009_user_params_table.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS user_params (
+    id SERIAL PRIMARY KEY,
+    user_id INT NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    UNIQUE (key, value)
+);
+
+INSERT INTO user_params
+SELECT nextval('user_params_id_seq'), id, (jsonb_each_text(params)).* FROM users;
+ALTER TABLE users DROP COLUMN params;

--- a/internal/modules/api/middleware.go
+++ b/internal/modules/api/middleware.go
@@ -26,9 +26,7 @@ func (api *API) checkAuth() func(http.Handler) http.Handler {
 				return
 			}
 
-			u, err := api.db.UsersGetByParams(&models.UserParams{
-				APIToken: token,
-			})
+			u, err := api.db.UsersGetByParam(models.UserAPIToken, token)
 
 			if err != nil {
 				handleError(api.log, w, r, errors.Unauthorizedf("invalid token"))

--- a/internal/modules/telegram/controller.go
+++ b/internal/modules/telegram/controller.go
@@ -75,7 +75,7 @@ func (tg *Telegram) Start() error {
 		chatID := update.Message.Chat.ID
 		text := update.Message.Text
 
-		u, err := tg.db.UsersGetByParams(&models.UserParams{TelegramID: chatID})
+		u, err := tg.db.UsersGetByParam(models.UserTelegramID, chatID)
 		if err != nil {
 			tg.handleError(chatID, errors.Unauthorized())
 			continue


### PR DESCRIPTION
There is no way in postgres to create unique index on jsonb key, so it is impossible to guarantee unique "api.token" and "telegram.id" for user. This PR moves unique user params to separate table with unique index.