### PR TITLE
Add CAA record for Let's encrypt

### DIFF
--- a/internal/handlers/dnsx/static.go
+++ b/internal/handlers/dnsx/static.go
@@ -26,6 +26,7 @@ var recordsTpl = tpl.MustParse(`
 {{- end }}
 @ 600 IN MX   10 mx
 * 600 IN MX   10 mx
+@ 600 IN CAA 0 issue "letsencrypt.org"
 `)
 
 func (h *DNSX) addStaticRecords() error {


### PR DESCRIPTION
fail to obtain certificate: acme: Error -> One or more domains had a problem:
acme: error: 400 :: urn:ietf:params:acme:error:dns :: DNS problem: SERVFAIL looking up CAA for pwnie.me - the domain's nameservers may be malfunctioning