### PR TITLE
Set TTL to 0 for subdomains

### DIFF
--- a/internal/handlers/dnsx/static.go
+++ b/internal/handlers/dnsx/static.go
@@ -12,20 +12,20 @@ import (
 
 var recordsTpl = tpl.MustParse(`
 @ IN 600 NS ns1
-* IN 600 NS ns1
+* IN 0 NS ns1
 @ IN 600 NS ns2
-* IN 600 NS ns2
+* IN 0 NS ns2
 {{ if .IP.To4 -}}
 @ IN 600 A    {{ .IP }}
-* IN 600 A    {{ .IP }}
-@ IN AAAA ::ffff:{{ .IP }}
+* IN A    {{ .IP }}
+@ IN 600 AAAA ::ffff:{{ .IP }}
 * IN AAAA ::ffff:{{ .IP }}
 {{- else -}}
-@ IN AAAA {{ .IP }}
+@ IN 600 AAAA {{ .IP }}
 * IN AAAA {{ .IP }}
 {{- end }}
 @ 600 IN MX   10 mx
-* 600 IN MX   10 mx
+* 0 IN MX   10 mx
 @ 600 IN CAA 0 issue "letsencrypt.org"
 `)
 


### PR DESCRIPTION
In some of previous commits TTL for some records was set to 600 which breaks DNS notifications